### PR TITLE
Update Spring to v3.3.0 and Thymeleaf. Update deprecated code

### DIFF
--- a/plantilla/pom.xml
+++ b/plantilla/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.8</version>
+		<version>3.3.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>es.ucm.fdi.iw</groupId>
@@ -14,9 +14,9 @@
 	<name>plantilla</name>                                  <!-- cambia esto -->
 	<description>Demo project for Spring Boot</description> <!-- cambia esto -->
 	<properties>
-		<java.version>11</java.version>
-		<maven.compiler.version>3.8.1</maven.compiler.version>
-        <maven.surefire.version>2.22.2</maven.surefire.version>        
+		<java.version>21</java.version>
+		<maven.compiler.version>3.13.0</maven.compiler.version>
+        <maven.surefire.version>3.2.5</maven.surefire.version>        
         <karate.version>1.1.0</karate.version>
 	</properties>
 	<dependencies>
@@ -43,6 +43,7 @@
 		<dependency>
 			<groupId>org.thymeleaf.extras</groupId>
 			<artifactId>thymeleaf-extras-springsecurity5</artifactId>
+			<version>3.1.2.RELEASE</version>
 		</dependency>
 
 		<dependency>

--- a/plantilla/src/main/java/es/ucm/fdi/iw/IwUserDetailsService.java
+++ b/plantilla/src/main/java/es/ucm/fdi/iw/IwUserDetailsService.java
@@ -2,8 +2,8 @@ package es.ucm.fdi.iw;
 
 import java.util.ArrayList;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/plantilla/src/main/java/es/ucm/fdi/iw/LoginSuccessHandler.java
+++ b/plantilla/src/main/java/es/ucm/fdi/iw/LoginSuccessHandler.java
@@ -3,11 +3,11 @@ package es.ucm.fdi.iw;
 import java.io.IOException;
 import java.util.Collection;
 
-import javax.persistence.EntityManager;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+import jakarta.persistence.EntityManager;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/plantilla/src/main/java/es/ucm/fdi/iw/SecurityConfig.java
+++ b/plantilla/src/main/java/es/ucm/fdi/iw/SecurityConfig.java
@@ -2,12 +2,11 @@ package es.ucm.fdi.iw;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
-import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -18,49 +17,47 @@ import org.springframework.security.crypto.password.PasswordEncoder;
  * https://spring.io/guides/topicals/spring-security-architecture/, it is not
  * a bad idea to also use method security (via @Secured annotations in methods) 
  */
+@Configuration
 @EnableWebSecurity
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class SecurityConfig {
 
 	@Autowired
 	private Environment env;
-
-	@Override
-    public void configure(WebSecurity web) throws Exception {
-		String debugProperty = env.getProperty("es.ucm.fdi.debug");
-		if (debugProperty != null && Boolean.parseBoolean(debugProperty.toLowerCase())) {
-			// allows access to h2 console iff running under debug mode
-			web.ignoring().antMatchers("/h2/**");
-		}
-    }
 
 	/**
 	 * Main security configuration.
 	 * 
 	 * The first rule that matches will be followed - so if a rule decides to grant access
 	 * to a resource, a later rule cannot deny that access, and vice-versa.
-	 * 
-	 * To disable security entirely, just add an .antMatchers("**").permitAll() 
-	 * as a first rule. Note that this may break an application that expects to have
-	 * login information available.
 	 */
-	@Override
-	protected void configure(HttpSecurity http) throws Exception {
-	    http
-			.csrf()
-				.ignoringAntMatchers("/api/**")
-				.and()
-	        .authorizeRequests()
-	            .antMatchers("/css/**", "/js/**", "/img/**", "/", "/error").permitAll()
-				.antMatchers("/api/**").permitAll()            // <-- public api access
-				.antMatchers("/admin/**").hasRole("ADMIN")	   // <-- administration
-	            .antMatchers("/user/**").hasRole("USER")	   // <-- logged-in users
-	            .anyRequest().authenticated()
-	            .and()
-			.formLogin()
-				.loginPage("/login")
-				.permitAll().successHandler(loginSuccessHandler); // <-- called when login Ok; can redirect
-	}
-	
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests((requests) -> {
+				String debugProperty = env.getProperty("es.ucm.fdi.debug");
+				if (debugProperty != null && Boolean.parseBoolean(debugProperty.toLowerCase())) {
+					// allows access to h2 console iff running under debug mode
+					requests.requestMatchers("/h2/**").permitAll();
+				}
+                requests.requestMatchers("/css/**", "/js/**", "/img/**", "/", "/error").permitAll()
+                        .requestMatchers("/api/**").permitAll()
+				        .requestMatchers("/admin/**").hasRole("ADMIN")
+	                    .requestMatchers("/user/**").hasRole("USER")
+                        .anyRequest().authenticated();
+            })
+			.csrf((csrf) -> csrf
+				.ignoringRequestMatchers("/api/**")
+			)
+            .formLogin((form) -> form
+                .loginPage("/login")
+                .loginProcessingUrl("/login")
+                .permitAll()
+                .successHandler(loginSuccessHandler)
+            )
+            .logout((logout) -> logout.permitAll());
+
+        return http.build();
+    }
+
 	/**
 	 * Declares a PasswordEncoder bean.
 	 * 
@@ -82,19 +79,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 	@Bean
 	public IwUserDetailsService springDataUserDetailsService() {
 		return new IwUserDetailsService();
-	} 
-	
-	/**
-	 * Declares an AuthenticationManager bean.
-	 * 
-	 * This can be used to auto-login into the site after creating new users, for example.
-	 */
-	 @Bean
-	 @Override
-	 public AuthenticationManager authenticationManagerBean() throws Exception {
-	     return super.authenticationManagerBean();
-	 }
+	}
 	 
-	 @Autowired
-	 private LoginSuccessHandler loginSuccessHandler;
+	@Autowired
+	private LoginSuccessHandler loginSuccessHandler;
 }

--- a/plantilla/src/main/java/es/ucm/fdi/iw/StartupConfig.java
+++ b/plantilla/src/main/java/es/ucm/fdi/iw/StartupConfig.java
@@ -8,7 +8,7 @@ import org.springframework.context.event.EventListener;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
-import javax.servlet.ServletContext;
+import jakarta.servlet.ServletContext;
 import java.text.SimpleDateFormat;
 
 /**

--- a/plantilla/src/main/java/es/ucm/fdi/iw/WebSocketSecurityConfig.java
+++ b/plantilla/src/main/java/es/ucm/fdi/iw/WebSocketSecurityConfig.java
@@ -1,8 +1,11 @@
 package es.ucm.fdi.iw;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.messaging.MessageSecurityMetadataSourceRegistry;
-import org.springframework.security.config.annotation.web.socket.AbstractSecurityWebSocketMessageBrokerConfigurer;
+import org.springframework.messaging.Message;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.config.annotation.web.socket.EnableWebSocketSecurity;
+import org.springframework.security.messaging.access.intercept.MessageMatcherDelegatingAuthorizationManager;
 
 import es.ucm.fdi.iw.model.User;
 
@@ -12,14 +15,14 @@ import es.ucm.fdi.iw.model.User;
  * @see https://docs.spring.io/spring-security/reference/servlet/integrations/websocket.html
  */
 @Configuration
-public class WebSocketSecurityConfig
-      extends AbstractSecurityWebSocketMessageBrokerConfigurer { 
-
-	
-    protected void configureInbound(MessageSecurityMetadataSourceRegistry messages) {
-        messages
-            .simpSubscribeDestMatchers("/topic/admin")	// only admins can subscribe
-            	.hasRole(User.Role.ADMIN.toString())
-            .anyMessage().authenticated(); 				// must log in to use websockets
+@EnableWebSocketSecurity
+public class WebSocketSecurityConfig {
+    @Bean
+    AuthorizationManager<Message<?>> messageAuthorizationManager(MessageMatcherDelegatingAuthorizationManager.Builder messages) {
+        // messages.simpDestMatchers("/user/**").authenticated();
+        messages.simpSubscribeDestMatchers("/topic/admin")	// only admins can subscribe
+                    .hasRole(User.Role.ADMIN.toString())
+                .anyMessage().authenticated(); 				// must log in to use websockets
+        return messages.build();
     }
 }

--- a/plantilla/src/main/java/es/ucm/fdi/iw/controller/RootController.java
+++ b/plantilla/src/main/java/es/ucm/fdi/iw/controller/RootController.java
@@ -5,6 +5,9 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  *  Non-authenticated requests only.
@@ -22,5 +25,25 @@ public class RootController {
 	@GetMapping("/")
     public String index(Model model) {
         return "index";
+    }
+    
+    @ModelAttribute("requestURI")
+    public String requestURI(final HttpServletRequest request) {
+        return request.getRequestURI();
+    }
+    
+    @ModelAttribute("requestURL")
+    public String requestURL(final HttpServletRequest request) {
+        return request.getRequestURL().toString();
+    }
+    
+    @ModelAttribute("userAgentHeader")
+    public String userAgentHeader(final HttpServletRequest request) {
+        return request.getHeader("User-Agent");
+    }
+
+    @ModelAttribute("requestQueryString")
+    public String requestQueryString(final HttpServletRequest request) {
+        return request.getQueryString();
     }
 }

--- a/plantilla/src/main/java/es/ucm/fdi/iw/controller/UserController.java
+++ b/plantilla/src/main/java/es/ucm/fdi/iw/controller/UserController.java
@@ -27,10 +27,10 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
-import javax.persistence.EntityManager;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-import javax.transaction.Transactional;
+import jakarta.persistence.EntityManager;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.transaction.Transactional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/plantilla/src/main/java/es/ucm/fdi/iw/model/Message.java
+++ b/plantilla/src/main/java/es/ucm/fdi/iw/model/Message.java
@@ -3,14 +3,14 @@ package es.ucm.fdi.iw.model;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.ManyToOne;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.SequenceGenerator;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.SequenceGenerator;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/plantilla/src/main/java/es/ucm/fdi/iw/model/User.java
+++ b/plantilla/src/main/java/es/ucm/fdi/iw/model/User.java
@@ -5,7 +5,7 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/plantilla/src/main/resources/application.properties
+++ b/plantilla/src/main/resources/application.properties
@@ -15,10 +15,10 @@ spring.jpa.hibernate.ddl-auto=create-drop
 spring.datasource.url=jdbc:h2:mem:iwdb
 # spring.datasource.url=jdbc:h2:file:./iwdb
 
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 # spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.hbm2ddl.import_files_sql_extractor=\
-org.hibernate.tool.hbm2ddl.MultipleLinesSqlCommandExtractor
+org.hibernate.tool.schema.internal.script.MultiLineSqlScriptExtractor
 
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2

--- a/plantilla/src/main/resources/templates/error.html
+++ b/plantilla/src/main/resources/templates/error.html
@@ -78,16 +78,16 @@
                 <table class="errTable">
                     <tr>
                         <td>req.url</td>
-                        <td th:text="${#request.requestURL}"></td>
+                        <td th:text="${requestURL}"></td>
                     </tr>
                     <tr>
                         <td>req.uri</td>
-                        <td th:text="${#request.requestURI}">
+                        <td th:text="${requestURI}">
                         </td>
                     </tr>
                     <tr>
                         <td>req.getHeader("User-Agent")</td>
-                        <td th:text="${#request.getHeader('User-Agent')}"></td>
+                        <td th:text="${userAgentHeader}"></td>
                     </tr>
                 </table>
 

--- a/plantilla/src/main/resources/templates/login.html
+++ b/plantilla/src/main/resources/templates/login.html
@@ -13,7 +13,7 @@
         <div class="container">
             <form class="form-signin" method="post" th:action="@{/login}">
                 <h2 class="form-signin-heading">Please sign in</h2>
-                <p th:if="${#request.getQueryString() == 'error'}" class="error">
+                <p th:if="${requestQueryString == 'error'}" class="error">
                     Error en nombre de usuario o contraseña
                 </p>
                 <p>


### PR DESCRIPTION
Estas modificaciones fueron realizadas por mi, y por mi compañero Dani @espiridifen.

Este código actualiza Spring (junto a Spring Security) y Thymeleaf a sus versiones más recientes. Se han realizado la menor cantidad de cambios posibles, a su vez manteniendo exactamente la misma funcionalidad.

En muchos de los archivos, el único cambio es de **javax** a **jakarta** (nuevo paquete que lo reemplaza).

Respecto a Spring Security, se ha modificado tanto el archivo de **SecurityConfig** como el de **WebSocketSecurityConfig**. Los cambios en este último son bastante sencillos y no requieren demasiada explicación.

En SecurityConfig sí hay más cambios, ya que ahora se utiliza la SecurityFilterChain (como su nombre indica, una cadena de filtros), y cambian los tipos como las funciones utilizadas, pero se mantiene la misma funcionalidad.

Respecto a **Thymeleaf**, en su última versión ya no se puede acceder a #request, y nos obligan a agregar los atributos al modelo directamente. Por eso los cambios en los archivos HTML y en el RootController.